### PR TITLE
Fix featured image when asset folder is set

### DIFF
--- a/layout/_partial/article-archive.ejs
+++ b/layout/_partial/article-archive.ejs
@@ -1,6 +1,10 @@
 <div class="item-0<%=index%>">
   <a href="<%- config.root %><%- item.path %>" class="post">
+    <% if (item.featured_image && config.post_asset_folder) { %>
+    <div class="thumb" style="background-image: url(<%- config.root %><%- item.path %><%- item.featured_image %>);"></div>
+      <% } else {%>
     <div class="thumb" style="background-image: url(<%- config.root %><%- item.featured_image || theme.featured_image %>);"></div>
+    <% }%>
     <article>
       <h1>
         <%=item.title %>

--- a/layout/_partial/article-excerpt.ejs
+++ b/layout/_partial/article-excerpt.ejs
@@ -2,7 +2,11 @@
 
 <div class="item-<%=index%>">
   <a href="<%- config.root %><%- item.path %>" class="post">
+    <% if (item.featured_image && config.post_asset_folder) { %>
+    <div class="thumb" style="background-image: url(<%- config.root %><%- item.path %><%- item.featured_image %>);"></div>
+    <% } else {%>
     <div class="thumb" style="background-image: url(<%- config.root %><%- item.featured_image || theme.featured_image %>);"></div>
+    <% }%>
     <article>
       <h1>
         <%=item.title %>


### PR DESCRIPTION
When `post_asset_folder` is set, the post path should be added to the 
URL of `featured_image`.